### PR TITLE
chore(ci): Skip GLPK tests with 3.13 on Linux

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,12 +63,18 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.11", "3.12", "3.13"]
         include:
-          - extras_best_effort: false
+          - extras_best_effort: false  # If True, try to install each extra separately and skip those that fail to install
+            skip_extras: ''            # JSON array of extras not to install
           - os: macos-latest
             python-version: 3.13
             extras_best_effort: true
           - os: windows-latest
             extras_best_effort: true
+          - os: ubuntu-latest
+            python-version: 3.13
+            # cvxopt wheel for 3.13 is bundled with GLPK 4.65, which has a known bug, see
+            # https://github.com/cvxopt/cvxopt-wheels/issues/8
+            skip_extras: '["glpk-mi"]'
 
     name: Python tests (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -92,17 +98,23 @@ jobs:
       run: uv sync
     
     - name: Install additional backends
-      if: ${{ ! matrix.extras_best_effort }}
+      if: ${{ ! matrix.extras_best_effort && matrix.skip_extras == '' }}
       run: uv sync --all-extras
     
     - name: Install additional backends (best effort)
-      if: ${{ matrix.extras_best_effort }}
+      if: ${{ matrix.extras_best_effort || matrix.skip_extras != '' }}
       env:
         NO_COLOR: 1
       shell: bash
       run: |
         while read -r -a extra_deps; do
           extra_name="${extra_deps[0]}"
+          if jq --exit-status --null-input --arg extra "${extra_name}" \
+             '${{ matrix.skip_extras && matrix.skip_extras || '[]' }} | contains([$extra])' > /dev/null;
+          then
+            echo "NOT installing $extra_name backend"
+            continue
+          fi
           deps=("${extra_deps[@]:1}")
           echo "::group::Installing $extra_name backend"
           uv pip install "${deps[@]}" \
@@ -111,7 +123,7 @@ jobs:
         done < <(
           # for each extra, output the extra name followed by the listed dependencies, space-separated
           uvx hatch project metadata \
-          | jq -r '."optional-dependencies" | to_entries[] | "\(.key) \(.value | join(" "))"'
+          | jq --raw-output '."optional-dependencies" | to_entries[] | "\(.key) \(.value | join(" "))"'
         )
 
     - name: Test with pytest


### PR DESCRIPTION
The cvxopt wheels for 3.13 come bundled with GLPK 4.65, which has a bug that's triggered by rummikub-solver in certain circumstances (leading to a hard crash), so avoid installing it.
