### PR TITLE
feat: Add new cvxpy backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade `cvxpy` dependency to 1.8.1 or up, and `cvxopt` to 1.3.3 or up to
   ensure Python 3.14 compatibility. Note that individual solver backends may
   still have narrower requirements.
+- Add Knitro (commercial solver) and cuOpt (GPU-accelerated solver) to backends.
+  ([#140](https://github.com/mjpieters/rummikub-solver/issues/140),
+   [#141](https://github.com/mjpieters/rummikub-solver/issues/141)).
 
 ## [1.0.0] - 2025-06-28
 

--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ You can also install an alternative Open Source solver backends via [extras][]:
 | `glpk_mi` | [GNU Linear Programming Kit](https://www.gnu.org/software/glpk/) | [GPL-3.0-only][gpl-30-only] | Installs the [cvxopt project](https://pypi.org/p/cvxopt) |
 | `highs` | [HiGHS][highs] | [MIT][mit] | Arguably the best OSS MILP solver available. This installs a newer version of HiGHS than what is bundled with SciPy. |
 | `scip` | [SCIP](https://scipopt.org/) | [Apache-2.0][apache-20] | |
+| | [cuOpt][cuopt] GPU-accelerated Optimization | [Apache-2.0][apache-20] | *No extra is provided as installation is more involved* |
 
 You can also pick from a number of commercial solvers; no extras are provided for these:
 
 - `COPT`: Cardinal Optimizer, <https://github.com/COPT-Public/COPT-Release>
 - `CPLEX`: IBM CPLEX, <https://www.ibm.com/docs/en/icos>
 - `GUROBI`: Gurobi Optimizer, <https://www.gurobi.com/>
+- `KNITRO`: <https://www.artelys.com/knitro/>
 - `MOSEK`: <https://www.mosek.com/>
 - `XPRESS`: Fico XPress,, <https://www.fico.com/en/products/fico-xpress-optimization>
 
@@ -92,6 +94,7 @@ When HiGHS is installed, it is automatically used as the default solver.
 [cpsolvers]: https://www.cvxpy.org/tutorial/solvers/index.html#choosing-a-solver
 [highs]: https://highs.dev/
 [extras]: https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-extras
+[cuopt]: https://github.com/NVIDIA/cuopt/
 
 <!-- --8<-- [end:picking_backend] -->
 

--- a/src/rummikub_solver/_types.py
+++ b/src/rummikub_solver/_types.py
@@ -132,6 +132,9 @@ class MILPSolver(StrEnum):
     CBC = "CBC"
     """COIN-OR (EPL-2.0), <https://github.com/coin-or/CyLP>"""
 
+    CUOPT = "CUOPT"
+    """cuOpt GPU-accelerated Optimization (Apache-2.0), <https://github.com/NVIDIA/cuopt>"""
+
     GLPK_MI = "GLPK_MI"
     """GNU Linear Programming Kit (GPL-3.0-only), <https://www.gnu.org/software/glpk/> (via [`cvxopt`](https://pypi.org/p/cvxopt))"""
 
@@ -153,6 +156,9 @@ class MILPSolver(StrEnum):
 
     GUROBI = "GUROBI"
     """Gurobi (LicenseRef-Proprietary), <https://www.gurobi.com/>"""
+
+    KNITRO = "KNITRO"
+    """Knitro (LicenseRef-Proprietary), <https://www.artelys.com/knitro/>"""
 
     MOSEK = "MOSEK"
     """Mosek (LicenseRef-Proprietary), <https://www.mosek.com/>"""


### PR DESCRIPTION
Add both cuOpt and Knitro backends to backend enum. While cuOpt is an OSS optimizer, its setup requirements are too involved for it to be practical as a package extra, so it is not included in the CI tests either. Knitro is a commercial optimizer.

Fixes #140
Fixes #141
