### PR TITLE
chore: clean up dep listing in ci, bump build deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
     "bot"
   ],
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+    "customManagers:githubActionsVersions"
   ],
   "pre-commit": {
     "enabled": true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,13 @@ on:
 
 env:
   FORCE_COLOR: 1
+  # renovate: datasource=nuget depName=yq
+  YQ_VERSION: 4.53.3
+  # renovate: datasource=pypi depName=uv-dynamic-versioning
+  UV_DYNAMIC_VERSIONING_VERSION: 0.14.0
+  # renovate: datasource=pypi depName=twine
+  TWINE_VERSION: 7.0.0
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -122,8 +129,8 @@ jobs:
 
     # Work around actions/runner-images#7443 and install yq on windows runners
     - name: Make yq tool available on Windows runners
-      if: "matrix.os == 'windows-latest'"
-      run: choco install yq --version 4.53.3
+      if: ${{ matrix.os == 'windows-latest' && (matrix.extras_best_effort || matrix.skip_extras == '') }}
+      run: choco install yq --version "$YQ_VERSION"
 
     - name: Install additional backends (best effort)
       if: ${{ matrix.extras_best_effort || matrix.skip_extras != '' }}
@@ -227,10 +234,10 @@ jobs:
       run: |
         uv build
         rm -f dist/.gitignore  # get-releasenotes can't handle non-dist files here
-        echo "version=$(uvx uv-dynamic-versioning@0.14.0)" >> "$GITHUB_OUTPUT"
+        echo "version=$(uvx uv-dynamic-versioning@"$UV_DYNAMIC_VERSIONING_VERSION")" >> "$GITHUB_OUTPUT"
 
     - name: Check build
-      run: uvx twine@7.0.0 check --strict dist/*
+      run: uvx twine@"$TWINE_VERSION" check --strict dist/*
 
     - name: Prepare Release Note
       id: note

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -120,6 +120,11 @@ jobs:
       if: ${{ ! matrix.extras_best_effort && matrix.skip_extras == '' }}
       run: uv sync --all-extras
 
+    # Work around actions/runner-images#7443 and install yq on windows runners
+    - name: Make yq tool available on Windows runners
+      if: "matrix.os == 'windows-latest'"
+      run: choco install yq --version 4.53.3
+
     - name: Install additional backends (best effort)
       if: ${{ matrix.extras_best_effort || matrix.skip_extras != '' }}
       env:
@@ -130,10 +135,12 @@ jobs:
         set -eu -o pipefail
         EXTRAS=$(
           # for each extra, output the extra name followed by the listed dependencies, space-separated
-          # This pins hatch to 1.15 or older to work around pypa/hatch#2118, and
-          # virtualenv 20.x or older, to work around pypa/hatch#2193.
-          uvx --from 'hatch<1.16' --with 'virtualenv<21' hatch project metadata \
-          | jq --raw-output '."optional-dependencies" | to_entries[] | "\(.key) \(.value | join(" "))"'
+          yq --output-format=yaml '
+              .project.optional-dependencies
+            | to_entries[]
+            | .value |= join(" ")
+            | "\(.key) \(.value)"
+          ' pyproject.toml
         )
         while read -r -a extra_deps; do
           extra_name="${extra_deps[0]}"
@@ -220,10 +227,10 @@ jobs:
       run: |
         uv build
         rm -f dist/.gitignore  # get-releasenotes can't handle non-dist files here
-        echo "version=$(uvx hatch version)" >> "$GITHUB_OUTPUT"
+        echo "version=$(uvx uv-dynamic-versioning@0.14.0)" >> "$GITHUB_OUTPUT"
 
     - name: Check build
-      run: uvx twine check --strict dist/*
+      run: uvx twine@7.0.0 check --strict dist/*
 
     - name: Prepare Release Note
       id: note

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ Issues = "https://github.com/mjpieters/rummikub-solver/issues"
 Changelog = "https://github.com/mjpieters/rummikub-solver/blob/main/CHANGELOG.md"
 
 [build-system]
-requires = ["hatchling~=1.27", "uv-dynamic-versioning~=0.8"]
+requires = ["hatchling>=1.31.0,<1.32.0", "uv-dynamic-versioning>=0.14.0,<0.15.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
@@ -66,6 +66,13 @@ source = "uv-dynamic-versioning"
 
 [tool.uv]
 required-version = "~=0.9"
+# Ensure that uv rebuilds the project when git commit or tags change
+# to update the version
+cache-keys = [
+    { file = "pyproject.toml" },
+    { git = { commit = true, tags = true } },
+    { env = "UV_DYNAMIC_VERSIONING_BYPASS" }
+]
 
 [tool.uv-dynamic-versioning]
 fallback-version = "0.0.0"


### PR DESCRIPTION
Use yq to list the project optional dependencies instead of hatch. This is less hassle and doesn't require version pinning.

While here use specific builder dependency pins, maintained by renovate, and pin any uvx tools to a specific version.
