### PR TITLE
chore: Reinstate full pydocstyle lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,11 @@ cache-keys = [
 [tool.uv-dynamic-versioning]
 fallback-version = "0.0.0"
 
+[tool.ruff.lint]
+extend-select = [
+    "D",  # pydocstyle
+]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D1"]  # tests do not require a docstring
 


### PR DESCRIPTION
This was dropped when the configuration was moved to ruff 0.16, but the default lint rules only include D419, not the full D lint ruleset.
